### PR TITLE
Finish reservoir merge into v3

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -788,7 +788,7 @@ def main_v03(argv):
     #     da_sets = [BIG LIST OF DA BLOCKS]
 
     if "wrf_hydro_parity_check" in output_parameters:
-        parity_sets = parity_parameters.get("parity_check_compare_file_sets", False)
+        parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])
     else:
         parity_sets = []
 
@@ -869,7 +869,7 @@ def main_v03(argv):
             supernetwork_parameters,
             output_parameters,
             parity_parameters,
-            parity_sets[run_set_iterator],
+            parity_sets[run_set_iterator] if parity_parameters else {},
             nts,
             compute_parameters.get("return_courant", False),
             showtiming,

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -547,8 +547,8 @@ def main_v02(argv):
         last_obs_df,
         run_parameters.get("assume_short_ts", False),
         run_parameters.get("return_courant", False),
-        waterbody_parameters,
         waterbodies_df,
+        waterbody_parameters,  # TODO: Can we remove the dependence on this input? It's like passing argv down into the compute kernel -- seems like we can strip out the specifically needed items.
         waterbody_types_df,
         waterbody_type_specified,
         diffusive_parameters,
@@ -692,6 +692,9 @@ def nwm_route(
     assume_short_ts,
     return_courant,
     waterbodies_df,
+    waterbody_parameters,
+    waterbody_types_df,
+    waterbody_type_specified,
     diffusive_parameters,
     showtiming=False,
     verbose=False,
@@ -733,6 +736,9 @@ def nwm_route(
         assume_short_ts,
         return_courant,
         waterbodies_df,
+        waterbody_parameters,
+        waterbody_types_df,
+        waterbody_type_specified,
         diffusive_parameters,
     )
 
@@ -790,7 +796,9 @@ def main_v03(argv):
         param_df,
         wbodies,
         waterbodies_df,
+        waterbody_types_df,
         break_network_at_waterbodies,
+        waterbody_type_specified,
         independent_networks,
         reaches_bytw,
         rconn,
@@ -802,6 +810,7 @@ def main_v03(argv):
         debuglevel=debuglevel,
     )
 
+    # TODO: This function modifies one of its arguments (waterbodies_df), which is somewhat poor practice given its otherwise functional nature. Consider refactoring
     waterbodies_df, q0, last_obs_df = nwm_initial_warmstate_preprocess(
         break_network_at_waterbodies,
         restart_parameters,
@@ -877,6 +886,9 @@ def main_v03(argv):
             assume_short_ts,
             return_courant,
             waterbodies_df,
+            waterbody_parameters,
+            waterbody_types_df,
+            waterbody_type_specified,
             diffusive_parameters,
             showtiming,
             verbose,

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -348,7 +348,7 @@ def main_v02(argv):
         )
 
         # Remove duplicate lake_ids and rows
-        waterbodies_df_reduced = (
+        waterbodies_df = (
             waterbodies_df.reset_index()
             .drop_duplicates(subset="lake_id")
             .set_index("lake_id")
@@ -356,7 +356,6 @@ def main_v02(argv):
 
         #Declare empty dataframe
         waterbody_types_df = pd.DataFrame()
-        waterbody_types_df_reduced = pd.DataFrame()
 
         #Check if hybrid-usgs, hybrid-usace, or rfc type reservoirs are set to true
         wbtype="hybrid_and_rfc"
@@ -377,7 +376,7 @@ def main_v02(argv):
                 wb_params_level_pool["level_pool_waterbody_id"], wbodies.values(),) 
 
             # Remove duplicate lake_ids and rows
-            waterbody_types_df_reduced = (
+            waterbody_types_df = (
                 waterbody_types_df.reset_index()
                 .drop_duplicates(subset="lake_id")
                 .set_index("lake_id")
@@ -385,8 +384,8 @@ def main_v02(argv):
 
     else:
         #Declare empty dataframe
-        waterbody_types_df_reduced = pd.DataFrame()
-        waterbodies_df_reduced = pd.DataFrame()
+        waterbody_types_df = pd.DataFrame()
+        waterbodies_df = pd.DataFrame()
 
     # STEP 2: Identify Independent Networks and Reaches by Network
     if showtiming:
@@ -396,7 +395,7 @@ def main_v02(argv):
 
     independent_networks, reaches_bytw, rconn = nnu.organize_independent_networks(
         connections,
-        list(waterbodies_df_reduced.index.values)
+        list(waterbodies_df.index.values)
         if break_network_at_waterbodies
         else None,
     )
@@ -438,8 +437,8 @@ def main_v02(argv):
                 len(waterbodies_initial_states_df)
             )
 
-        waterbodies_df_reduced = pd.merge(
-            waterbodies_df_reduced, waterbodies_initial_states_df, on="lake_id"
+        waterbodies_df = pd.merge(
+            waterbodies_df, waterbodies_initial_states_df, on="lake_id"
         )
 
         if verbose:
@@ -548,9 +547,9 @@ def main_v02(argv):
         last_obs_df,
         run_parameters.get("assume_short_ts", False),
         run_parameters.get("return_courant", False),
-        waterbodies_df_reduced,
         waterbody_parameters,
-        waterbody_types_df_reduced,
+        waterbodies_df,
+        waterbody_types_df,
         waterbody_type_specified,
         diffusive_parameters,
     )

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -339,6 +339,8 @@ def main_v02(argv):
     # waterbodies_segments = supernetwork_values[13]
     # connections_tailwaters = supernetwork_values[4]
 
+    waterbody_type_specified = False
+
     if break_network_at_waterbodies:
         # Read waterbody parameters
         waterbodies_df = nhd_io.read_waterbody_df(
@@ -351,7 +353,39 @@ def main_v02(argv):
             .drop_duplicates(subset="lake_id")
             .set_index("lake_id")
         )
+
+        #Declare empty dataframe
+        waterbody_types_df = pd.DataFrame()
+        waterbody_types_df_reduced = pd.DataFrame()
+
+        #Check if hybrid-usgs, hybrid-usace, or rfc type reservoirs are set to true
+        wbtype="hybrid_and_rfc"
+        wb_params_hybrid_and_rfc = waterbody_parameters[wbtype]
+
+        wbtype="level_pool"
+        wb_params_level_pool = waterbody_parameters[wbtype]
+
+        waterbody_type_specified = False
+
+        if wb_params_hybrid_and_rfc["reservoir_persistence_usgs"] \
+        or wb_params_hybrid_and_rfc["reservoir_persistence_usace"] \
+        or wb_params_hybrid_and_rfc["reservoir_rfc_forecasts"]:
+
+            waterbody_type_specified = True
+
+            waterbody_types_df = nhd_io.read_reservoir_parameter_file(wb_params_hybrid_and_rfc["reservoir_parameter_file"], \
+                wb_params_level_pool["level_pool_waterbody_id"], wbodies.values(),) 
+
+            # Remove duplicate lake_ids and rows
+            waterbody_types_df_reduced = (
+                waterbody_types_df.reset_index()
+                .drop_duplicates(subset="lake_id")
+                .set_index("lake_id")
+            )
+
     else:
+        #Declare empty dataframe
+        waterbody_types_df_reduced = pd.DataFrame()
         waterbodies_df_reduced = pd.DataFrame()
 
     # STEP 2: Identify Independent Networks and Reaches by Network
@@ -515,6 +549,9 @@ def main_v02(argv):
         run_parameters.get("assume_short_ts", False),
         run_parameters.get("return_courant", False),
         waterbodies_df_reduced,
+        waterbody_parameters,
+        waterbody_types_df_reduced,
+        waterbody_type_specified,
         diffusive_parameters,
     )
 

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -19,32 +19,33 @@ def nwm_output_generator(
     debuglevel=0,
 ):
 
-    parity_check_file = parity_parameters.get("parity_check_file", None)
-    parity_check_input_folder = parity_parameters.get("parity_check_input_folder", None)
-    parity_check_file_index_col = parity_parameters.get(
-        "parity_check_file_index_col", None
-    )
-    parity_check_file_value_col = parity_parameters.get(
-        "parity_check_file_value_col", None
-    )
-    parity_check_compare_node = parity_parameters.get("parity_check_compare_node", None)
+    if parity_parameters:
+        parity_check_file = parity_parameters.get("parity_check_file", None)
+        parity_check_input_folder = parity_parameters.get("parity_check_input_folder", None)
+        parity_check_file_index_col = parity_parameters.get(
+            "parity_check_file_index_col", None
+        )
+        parity_check_file_value_col = parity_parameters.get(
+            "parity_check_file_value_col", None
+        )
+        parity_check_compare_node = parity_parameters.get("parity_check_compare_node", None)
 
-    # TODO: find a better way to deal with these defaults and overrides.
-    parity_set["parity_check_file"] = parity_set.get(
-        "parity_check_file", parity_check_file
-    )
-    parity_set["parity_check_input_folder"] = parity_set.get(
-        "parity_check_input_folder", parity_check_input_folder
-    )
-    parity_set["parity_check_file_index_col"] = parity_set.get(
-        "parity_check_file_index_col", parity_check_file_index_col
-    )
-    parity_set["parity_check_file_value_col"] = parity_set.get(
-        "parity_check_file_value_col", parity_check_file_value_col
-    )
-    parity_set["parity_check_compare_node"] = parity_set.get(
-        "parity_check_compare_node", parity_check_compare_node
-    )
+        # TODO: find a better way to deal with these defaults and overrides.
+        parity_set["parity_check_file"] = parity_set.get(
+            "parity_check_file", parity_check_file
+        )
+        parity_set["parity_check_input_folder"] = parity_set.get(
+            "parity_check_input_folder", parity_check_input_folder
+        )
+        parity_set["parity_check_file_index_col"] = parity_set.get(
+            "parity_check_file_index_col", parity_check_file_index_col
+        )
+        parity_set["parity_check_file_value_col"] = parity_set.get(
+            "parity_check_file_value_col", parity_check_file_value_col
+        )
+        parity_set["parity_check_compare_node"] = parity_set.get(
+            "parity_check_compare_node", parity_check_compare_node
+        )
 
     ################### Output Handling
     if showtiming:

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -173,12 +173,7 @@ def nwm_output_generator(
 
     ################### Parity Check
 
-    if (
-        "parity_check_input_folder" in parity_parameters
-        or "parity_check_file" in parity_parameters
-        or "parity_check_waterbody_file" in parity_parameters
-    ):
-
+    if parity_set:
         if verbose:
             print(
                 "conducting parity check, comparing WRF Hydro results against t-route results"

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -20,6 +20,7 @@ def nwm_output_generator(
 ):
 
     if parity_parameters:
+        parity_check_waterbody_file = parity_parameters.get("parity_check_waterbody_file", None)
         parity_check_file = parity_parameters.get("parity_check_file", None)
         parity_check_input_folder = parity_parameters.get("parity_check_input_folder", None)
         parity_check_file_index_col = parity_parameters.get(
@@ -31,6 +32,9 @@ def nwm_output_generator(
         parity_check_compare_node = parity_parameters.get("parity_check_compare_node", None)
 
         # TODO: find a better way to deal with these defaults and overrides.
+        parity_set["parity_check_waterbody_file"] = parity_set.get(
+            "parity_check_waterbody_file", parity_check_waterbody_file
+        )
         parity_set["parity_check_file"] = parity_set.get(
             "parity_check_file", parity_check_file
         )

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -19,6 +19,7 @@ def nwm_output_generator(
     debuglevel=0,
 ):
 
+    parity_check_file = parity_parameters.get("parity_check_file", None)
     parity_check_input_folder = parity_parameters.get("parity_check_input_folder", None)
     parity_check_file_index_col = parity_parameters.get(
         "parity_check_file_index_col", None
@@ -29,6 +30,9 @@ def nwm_output_generator(
     parity_check_compare_node = parity_parameters.get("parity_check_compare_node", None)
 
     # TODO: find a better way to deal with these defaults and overrides.
+    parity_set["parity_check_file"] = parity_set.get(
+        "parity_check_file", parity_check_file
+    )
     parity_set["parity_check_input_folder"] = parity_set.get(
         "parity_check_input_folder", parity_check_input_folder
     )

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -166,7 +166,9 @@ def parity_check(
     compare_node = parity_set["parity_check_compare_node"]
 
     parity_check_input_folder = parity_set.get("parity_check_input_folder", None)
-    parity_check_input_file = parity_set.get("parity_check_input_file", None)
+    parity_check_file = parity_set.get("parity_check_file", None)
+    parity_check_waterbody_file = parity_set.get("parity_check_waterbody_file", None)
+
     if parity_check_input_folder:
         parity_check_input_folder = pathlib.Path(parity_check_input_folder)
         if "validation_files" in parity_set:
@@ -187,13 +189,13 @@ def parity_check(
             # [compare_node],
         )
 
-    elif "parity_check_file" in parity_set:
+    elif parity_check_file:
         validation_data = pd.read_csv(parity_set["parity_check_file"], index_col=0)
         validation_data.index = validation_data.index.astype(int)
         validation_data.columns = validation_data.columns.astype("datetime64[ns]")
         validation_data = validation_data.sort_index(axis="index")
 
-    elif "parity_check_waterbody_file" in parity_set:
+    elif parity_check_waterbody_file:
         validation_data = pd.read_csv(
             parity_set["parity_check_waterbody_file"], index_col=0
         )

--- a/test/input/yaml/Croton_NY_levelpool_loop.yaml
+++ b/test/input/yaml/Croton_NY_levelpool_loop.yaml
@@ -91,10 +91,10 @@ output_parameters:
     nc_output_folder: "../../test/output/text"
     wrf_hydro_parity_check:
         #Use two lines below for parity check on streamflow and leave the following two lines commented out
-        parity_check_compare_file_sets:
-            - parity_check_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/streamflow_croton_levelpool.csv"
-              parity_check_compare_node: 6227150 #Stream
-        #Use two lines below for parity check on reservoir/waterbody and comment out two lines above
         # parity_check_compare_file_sets:
-        #      - parity_check_waterbody_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/waterbodies/reservoir_outflow_croton_levelpool_warm_nudge_off.csv"
-        #        parity_check_compare_node: 6228110 #Reservoir - only reservoir in domain
+        #     - parity_check_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/streamflow_croton_levelpool.csv"
+        #       parity_check_compare_node: 6227150 #Stream
+        #Use two lines below for parity check on reservoir/waterbody and comment out two lines above
+        parity_check_compare_file_sets:
+            - parity_check_waterbody_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/waterbodies/reservoir_outflow_croton_levelpool_warm_nudge_off.csv"
+              parity_check_compare_node: 6228110 #Reservoir - only reservoir in domain

--- a/test/input/yaml/Croton_NY_levelpool_loop.yaml
+++ b/test/input/yaml/Croton_NY_levelpool_loop.yaml
@@ -1,0 +1,100 @@
+---
+#initial input parameters
+log_parameters:
+    verbose: true  # verbose output (leave blank for quiet output.)
+    showtiming: true  # set the showtiming (omit flag for no timing information.)
+    debuglevel: 1  # set the debuglevel for additional console output.
+network_topology_parameters:
+    #data column assignment inside supernetwork_parameters
+    supernetwork_parameters:
+        title_string: "Croton1"
+        geo_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        #mask_file_path: ""
+        #mask_layer_string: ""
+        #mask_driver_string: "csv"
+        #mask_key: 0
+        columns:
+            key: "link"
+            downstream: "to"
+            dx: "Length"
+            n: "n"  # TODO: rename to `manningn`
+            ncc: "nCC"  # TODO: rename to `mannningncc`
+            s0: "So"  # TODO: rename to `bedslope`
+            bw: "BtmWdth"  # TODO: rename to `bottomwidth`
+            waterbody: "NHDWaterbodyComID"
+            tw: "TopWdth"  # TODO: rename to `topwidth`
+            twcc: "TopWdthCC"  # TODO: rename to `topwidthcc`
+            alt: "alt"
+            musk: "MusK"
+            musx: "MusX"
+            cs: "ChSlp"  # TODO: rename to `sideslope`
+        waterbody_null_code: -9999
+        terminal_code: 0
+        driver_string: NetCDF
+        layer_string: 0
+    #waterbody parameters and assignments from lake parm file
+    waterbody_parameters:
+        break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
+                          # WARNING: `break_network_at_waterbodies: true` will only work if compute_kernel is set to "V02-structured-obj" and parallel_compute_method is unset (serial execution) or set to "by-network".
+        level_pool:
+            #WRF-Hydro lake parm file
+            level_pool_waterbody_parameter_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/LAKEPARM.nc"
+            level_pool_waterbody_id: lake_id
+            level_pool_waterbody_area: LkArea
+            level_pool_weir_elevation: WeirE
+            level_pool_waterbody_max_elevation: LkMxE
+            level_pool_outfall_weir_coefficient: WeirC
+            level_pool_outfall_weir_length: WeirL
+            level_pool_overall_dam_length: DamL
+            level_pool_orifice_elevation: OrificeE
+            level_pool_orifice_coefficient: OrificeC
+            level_pool_orifice_area: OrificeA
+compute_parameters:
+    parallel_compute_method: by-network  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    cpu_pool: 4
+    # subnetwork_target_size: 100  # by-subnetwork* requires a value here to identify the target subnetwork size.
+    compute_kernel: V02-structured-obj  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
+    assume_short_ts: true  # use the previous timestep value for both current and previous flow.
+    return_courant: false  # WARNING: true will only work with compute_kernel "V02-caching", therefore not currently compatible with simulation for waterbodies.
+    #WRF-Hydro restart files
+    restart_parameters:
+        #WRF-Hydro channels restart file
+        wrf_hydro_channel_restart_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_RESTART/HYDRO_RST.2011-08-26_00-00_DOMAIN1"
+        #WRF-Hydro channels ID crosswalk file
+        wrf_hydro_channel_ID_crosswalk_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        wrf_hydro_channel_ID_crosswalk_file_field_name: link
+        wrf_hydro_channel_restart_upstream_flow_field_name: qlink1
+        wrf_hydro_channel_restart_downstream_flow_field_name: qlink2
+        wrf_hydro_channel_restart_depth_flow_field_name: hlink
+        #WRF-Hydro waterbodies restart file
+        wrf_hydro_waterbody_restart_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_RESTART/HYDRO_RST.2011-08-26_00-00_DOMAIN1"
+        #WRF-Hydro waterbody ID crosswalk file
+        wrf_hydro_waterbody_ID_crosswalk_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/LAKEPARM.nc"
+        wrf_hydro_waterbody_ID_crosswalk_file_field_name: lake_id
+        #WRF-Hydro waterbody crosswalk filter file
+        wrf_hydro_waterbody_crosswalk_filter_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        wrf_hydro_waterbody_crosswalk_filter_file_field_name: NHDWaterbodyComID
+    #output file parameters
+    #(Reformatted from a WRF-Hydro output file)
+    forcing_parameters:
+        qts_subdivisions: 12  # number of timesteps per forcing (qlateral) timestep.
+        dt: 300  # default timestep length, seconds
+        qlat_forcing_sets:
+            - qlat_input_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/qlats_croton.csv"
+              nts: 288
+output_parameters:
+    #output location for csv file
+    csv_output:
+        csv_output_folder: "../../test/output/text"
+        csv_output_segments: []
+    #out location for nc file
+    nc_output_folder: "../../test/output/text"
+    wrf_hydro_parity_check:
+        #Use two lines below for parity check on streamflow and leave the following two lines commented out
+        parity_check_compare_file_sets:
+            - parity_check_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/streamflow_croton_levelpool.csv"
+              parity_check_compare_node: 6227150 #Stream
+        #Use two lines below for parity check on reservoir/waterbody and comment out two lines above
+        # parity_check_compare_file_sets:
+        #      - parity_check_waterbody_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/waterbodies/reservoir_outflow_croton_levelpool_warm_nudge_off.csv"
+        #        parity_check_compare_node: 6228110 #Reservoir - only reservoir in domain

--- a/test/input/yaml/Croton_NY_rfc_loop.yaml
+++ b/test/input/yaml/Croton_NY_rfc_loop.yaml
@@ -1,0 +1,123 @@
+---
+#initial input parameters
+log_parameters:
+    verbose: true  # verbose output (leave blank for quiet output.)
+    showtiming: true  # set the showtiming (omit flag for no timing information.)
+    debuglevel: 1  # set the debuglevel for additional console output.
+network_topology_parameters:
+    supernetwork_parameters:
+        title_string: "Croton1"
+        geo_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        #mask_file_path: ""
+        #mask_layer_string: ""
+        #mask_driver_string: "csv"
+        #mask_key: 0
+        columns:
+            key: "link"
+            downstream: "to"
+            dx: "Length"
+            n: "n"  # TODO: rename to `manningn`
+            ncc: "nCC"  # TODO: rename to `mannningncc`
+            s0: "So"  # TODO: rename to `bedslope`
+            bw: "BtmWdth"  # TODO: rename to `bottomwidth`
+            waterbody: "NHDWaterbodyComID"
+            tw: "TopWdth"  # TODO: rename to `topwidth`
+            twcc: "TopWdthCC"  # TODO: rename to `topwidthcc`
+            alt: "alt"
+            musk: "MusK"
+            musx: "MusX"
+            cs: "ChSlp"  # TODO: rename to `sideslope`
+        waterbody_null_code: -9999
+        terminal_code: 0
+        driver_string: NetCDF
+        layer_string: 0
+
+    #waterbody parameters and assignments from lake parm file
+    waterbody_parameters:
+        break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
+        level_pool:
+            #WRF-Hydro lake parm file
+            level_pool_waterbody_parameter_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/LAKEPARM.nc"
+            level_pool_waterbody_id: lake_id
+            level_pool_waterbody_area: LkArea
+            level_pool_weir_elevation: WeirE
+            level_pool_waterbody_max_elevation: LkMxE
+            level_pool_outfall_weir_coefficient: WeirC
+            level_pool_outfall_weir_length: WeirL
+            level_pool_overall_dam_length: DamL
+            level_pool_orifice_elevation: OrificeE
+            level_pool_orifice_coefficient: OrificeC
+            level_pool_orifice_area: OrificeA
+
+        hybrid_and_rfc:
+            # Specify the reservoir parameter file
+            reservoir_parameter_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/reservoir_index_croton_ny_rfc.nc"
+
+            # If using USGS persistence reservoirs, set to True. (default=.FALSE.)
+            reservoir_persistence_usgs: False
+
+            # Specify the path to the timeslice files to be used by USGS reservoirs
+            reservoir_usgs_timeslice_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
+
+            # If using USACE persistence reservoirs, set to True. (default=.FALSE.)
+            reservoir_persistence_usace: False
+
+            # Specify the path to the timeslice files to be used by USACE reservoirs
+            reservoir_usace_timeslice_path: ""
+
+            # Specify lookback hours to read reservoir observation data
+            reservoir_observation_lookback_hours: 48
+
+            # Specify update time interval in seconds to read new reservoir observation data
+            # The default is 86400 (seconds per day). Set to 3600 for standard and extended AnA simulations.
+            # Set to 1000000000 for short range and medium range forecasts.
+            reservoir_observation_update_time_interval_seconds: 1000000000
+            
+            # If using RFC forecast reservoirs, set to True. (default=.FALSE.)
+            reservoir_rfc_forecasts: True
+
+            # Specify the path to the RFC time series files to be used by reservoirs
+            reservoir_rfc_forecasts_time_series_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
+
+            # Specify lookback hours to read reservoir RFC forecasts
+            reservoir_rfc_forecasts_lookback_hours: 48
+
+compute_parameters:
+    parallel_compute_method: by-network  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    cpu_pool: 4
+    compute_kernel: V02-structured-obj  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
+    assume_short_ts: true
+    return_courant: false
+    restart_parameters:
+        #WRF-Hydro channels restart file
+        wrf_hydro_channel_restart_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_RESTART/HYDRO_RST.2011-08-26_00-00_DOMAIN1"
+        #WRF-Hydro channels ID crosswalk file
+        wrf_hydro_channel_ID_crosswalk_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        wrf_hydro_channel_ID_crosswalk_file_field_name: link
+        wrf_hydro_channel_restart_upstream_flow_field_name: qlink1
+        wrf_hydro_channel_restart_downstream_flow_field_name: qlink2
+        wrf_hydro_channel_restart_depth_flow_field_name: hlink
+        #WRF-Hydro waterbodies restart file
+        wrf_hydro_waterbody_restart_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_RESTART/HYDRO_RST.2011-08-26_00-00_DOMAIN1"
+        #WRF-Hydro waterbody ID crosswalk file
+        wrf_hydro_waterbody_ID_crosswalk_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/LAKEPARM.nc"
+        wrf_hydro_waterbody_ID_crosswalk_file_field_name: lake_id
+        #WRF-Hydro waterbody crosswalk filter file
+        wrf_hydro_waterbody_crosswalk_filter_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/Route_Link.nc"
+        wrf_hydro_waterbody_crosswalk_filter_file_field_name: NHDWaterbodyComID
+    forcing_parameters:
+        qts_subdivisions: 12  # number of timesteps per forcing (qlateral) timestep.
+        dt: 300  # default timestep length, seconds
+        return_courant: false  # WARNING: true will only work with compute_method "V02-caching", therefore not currently compatible with simulation for waterbodies.
+        qlat_forcing_sets:
+            - qlat_input_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/qlats_croton.csv"
+              nts: 288  # number of timesteps to simulate. If used with ql_file or ql_folder, nts must be less than the number of ql inputs x qts_subdivisions.
+output_parameters:
+    wrf_hydro_parity_check:
+        #Use two lines below for parity check on streamflow and leave the following two lines commented out
+        #parity_check_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/example_CHRTOUT/streamflow_croton_levelpool.csv"
+        #parity_check_compare_node: 6227150 #Stream
+        #Use two lines below for parity check on reservoir/waterbody and comment out two lines above
+        parity_check_compare_file_sets:
+            - parity_check_waterbody_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/waterbodies/reservoir_outflow_croton_rfc_nudge_off.csv"
+              parity_check_compare_node: 6228110 #Reservoir - only reservoir in domain

--- a/test/input/yaml/CustomInput_loop.yaml
+++ b/test/input/yaml/CustomInput_loop.yaml
@@ -31,7 +31,7 @@ network_topology_parameters:
         terminal_code: 0
         driver_string: NetCDF
         layer_string: 0
-        #waterbody parameters and assignments from lake parm file
+    #waterbody parameters and assignments from lake parm file
     waterbody_parameters:
         break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
                               # TODO: Remove the following limitation


### PR DESCRIPTION
Supersedes #3 
Added a test case for the Croton Level pool example using the new V3 input file structure.
Manually incorporated the changes to former `compute_nhd_routing_v02.py` script into appropriate locations in `__main__.py` and `compute.py`

- [ ]  python -m nwm_routing -V2 -f ../../test/input/yaml/Croton_NY_with_wb_dev.yaml -- currently fails with input error
- [x] python -m nwm_routing -V2 -f ../../test/input/yaml/Croton_NY_levelpool.yaml
- [x] python -m nwm_routing -V3 -f ../../test/input/yaml/Croton_NY_levelpool_loop.yaml
- [x] python -m nwm_routing -V2 -f ../../test/input/yaml/Croton_NY_rfc.yaml
- [x] python -m nwm_routing -V3 -f ../../test/input/yaml/Croton_NY_rfc_loop.yaml
- [ ] python -m nwm_routing -V2 -f ../../test/input/yaml/Croton_NY_hybrid_usgs.yaml -- currently core dumps
